### PR TITLE
Bump httpclient from 4.5.5 to 4.5.13 in /shipping

### DIFF
--- a/shipping/pom.xml
+++ b/shipping/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
+            <version>4.5.13</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Bumps httpclient from 4.5.5 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>